### PR TITLE
Update doveadm-search-query.7

### DIFF
--- a/doc/man/doveadm-search-query.7
+++ b/doc/man/doveadm-search-query.7
@@ -266,7 +266,7 @@ in the SUBJECT field of the message\(aqs IMAP envelope structure.
 .BI TEXT\  string
 Matches messages, which contain
 .I string
-in the message body.
+in the message header and body.
 .\"-----------------
 .TP
 .BI TO\  string


### PR DESCRIPTION
According to RFC3501 and a test on dovecot 2.3.11.3 (502c39af9), doveadm search with search key TEXT search in the header and body of the message. This is not clear in the man page.

Command:
doveadm search -u user@example.org INBOX TEXT test

but man page doveadm-search-query said:
      TEXT string
              Matches messages, which contain string in the message body.

https://tools.ietf.org/html/rfc3501#section-6.4.4
      TEXT <string>
         Messages that contain the specified string in the header or
         body of the message.